### PR TITLE
Update google-docs.css

### DIFF
--- a/google-docs/google-docs.css
+++ b/google-docs/google-docs.css
@@ -43,3 +43,13 @@
     border: none;
 }
 */
+
+/*
+.kix-page-canvas-compact-mode {
+    border-top: none!important; 
+}
+
+.kix-page-paginated .kix-stacked-tile-page-shadow{
+    box-shadow: none!important;
+}
+*/


### PR DESCRIPTION
This might not be needed but I tried running this with stylus and it wasn't getting rid of the line breaks in print mode so I searched around and found these properties which worked (commented out at the bottom)